### PR TITLE
Update 09 - WinForms - DataBinding, UnitTesting.md

### DIFF
--- a/09 - WinForms - DataBinding, UnitTesting.md
+++ b/09 - WinForms - DataBinding, UnitTesting.md
@@ -132,7 +132,7 @@ Cases:
 		#region INotifyPropertyChanged
 		public event PropertyChangedEventHandler PropertyChanged;
 
-		[NotifyPropertyChangedInvocator]
+		[NotifyPropertyChangedInvocator] //Remove this line if you are not using Resharper
 		// [CallerMemberName] - Allows you to obtain the method or property name of the caller to the method. https://msdn.microsoft.com/en-us/library/system.runtime.compilerservices.callermembernameattribute%28v=vs.110%29.aspx
 		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{


### PR DESCRIPTION
NotifyPropertyChangedInvocator is a Resharper feature and will give you an error if you are not using Resharper. Some people might be confused by that error.